### PR TITLE
Update _utils.py

### DIFF
--- a/pandas_datareader/_utils.py
+++ b/pandas_datareader/_utils.py
@@ -24,11 +24,15 @@ def _sanitize_dates(start, end):
     if is_number(start):
         # regard int as year
         start = dt.datetime(start, 1, 1)
-    start = to_datetime(start)
+    else:
+        # it may fail in pandas 0.18.1 if we don't infer
+        start = to_datetime(start, infer_datetime_format=True)
 
     if is_number(end):
         end = dt.datetime(end, 1, 1)
-    end = to_datetime(end)
+    else:
+        # it may fail in pandas 0.18.1 if we don't infer
+        end = to_datetime(end, infer_datetime_format=True)
 
     if start is None:
         start = dt.datetime(2010, 1, 1)


### PR DESCRIPTION
on my setup, python 3.6.3 pandas 0.18.1. It failed with weird error:

(Pdb) pd.to_datetime('1/1/1970')
*** SystemError: <class 'str'> returned a result with an error set

after adding infer_datetime_format, it works.

(Pdb) pd.to_datetime('1/1/1970', infer_datetime_format=True)
Timestamp('1970-01-01 00:00:00')

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
